### PR TITLE
Fixed-Time Motion V2

### DIFF
--- a/InputShaping.py
+++ b/InputShaping.py
@@ -21,7 +21,10 @@ class InputShaping(Script):
                     "type": "enum",
                     "options": {
                         "is": "M593 (ZV Input Shaping)",
-                        "ftm": "M493 (Fixed-Time Motion)"
+                        "ftm": "M493 (Fixed-Time Motion)",
+                        "oldis": "Beta M593 (ZV Input Shaping)",
+                        "oldftm": "Beta M493 (Fixed-Time Motion)",
+                        "voldftm": "Alpha M493 (Fixed-Time Motion)"
                     },
                     "default_value": "is"
                 },
@@ -55,13 +58,26 @@ class InputShaping(Script):
                 elif line.startswith(';LAYER:'):
                     layer = float(line.strip(';LAYER:'))
                     hz = 0 if layer < 2 else start_hz + (end_hz-start_hz) * (layer - 2) / (max_layer-3)
-                    if gc == 'ftm':
-                        if layer == 0:
-                            lines[j] += '\n;TYPE:INPUTSHAPING\nM493 S11 D0 ;Enable ZVD Input Shaping'
+                    if layer == 0:
+                        params = ""
+                        if gc == 'voldftm':
+                            params = "S11"
+                        else if gc == 'oldftm':
+                            params = "S1 X11 Y11"
+                        else if gc == 'ftm':
+                            params = "S1 XY C11"
+                        if params:
+                            lines[j] += '\n;TYPE:INPUTSHAPING\nM493 %s D0 ;Enable ZVD Input Shaping' % params
+
+                    if gc in ('oldftm','voldftm'):
                         lines[j] += '\n;TYPE:INPUTSHAPING\nM493 A%f ;(Hz) X Input Shaping Test' % hz
                         lines[j] += '\nM493 B%f ;(Hz) Y Input Shaping Test' % hz
-                    if gc == 'is':
+                    else if gc == 'ftm':
+                        lines[j] += '\n;TYPE:INPUTSHAPING\nM493 XY A%f ;(Hz) XY Input Shaping Test' % hz
+                    else if gc == 'oldis':
                         lines[j] += '\n;TYPE:INPUTSHAPING\nM593 F%f ;(Hz) Input Shaping Test' % hz
+                    else if gc == 'is':
+                        lines[j] += '\n;TYPE:INPUTSHAPING\nM593 XY F%f ;(Hz) Input Shaping Test' % hz
             data[i] = '\n'.join(lines)
 
         return data

--- a/InputShaping.py
+++ b/InputShaping.py
@@ -62,9 +62,9 @@ class InputShaping(Script):
                         params = ""
                         if gc == 'voldftm':
                             params = "S11"
-                        else if gc == 'oldftm':
+                        elif gc == 'oldftm':
                             params = "S1 X11 Y11"
-                        else if gc == 'ftm':
+                        elif gc == 'ftm':
                             params = "S1 XY C11"
                         if params:
                             lines[j] += '\n;TYPE:INPUTSHAPING\nM493 %s D0 ;Enable ZVD Input Shaping' % params
@@ -72,11 +72,11 @@ class InputShaping(Script):
                     if gc in ('oldftm','voldftm'):
                         lines[j] += '\n;TYPE:INPUTSHAPING\nM493 A%f ;(Hz) X Input Shaping Test' % hz
                         lines[j] += '\nM493 B%f ;(Hz) Y Input Shaping Test' % hz
-                    else if gc == 'ftm':
+                    elif gc == 'ftm':
                         lines[j] += '\n;TYPE:INPUTSHAPING\nM493 XY A%f ;(Hz) XY Input Shaping Test' % hz
-                    else if gc == 'oldis':
+                    elif gc == 'oldis':
                         lines[j] += '\n;TYPE:INPUTSHAPING\nM593 F%f ;(Hz) Input Shaping Test' % hz
-                    else if gc == 'is':
+                    elif gc == 'is':
                         lines[j] += '\n;TYPE:INPUTSHAPING\nM593 XY F%f ;(Hz) Input Shaping Test' % hz
             data[i] = '\n'.join(lines)
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # cura-ringing-tower-script
-Cura implementation of custom layer change G-code macro used in slicing *ringing tower STL* for M593 (https://marlinfw.org/docs/gcode/M593.html) or M493 (https://marlinfw.org/docs/gcode/M493.html) based input shaping.
+Cura implementation of custom layer change G-code macro used in slicing [Ringing Tower STL](//marlinfw.org/assets/stl/ringing_tower.stl) for [M593](//marlinfw.org/docs/gcode/M593.html) or [M493](//marlinfw.org/docs/gcode/M493.html) based input shaping.
 Use the script with Post Processing Plugin on Cura Marketplace.
 
-Copy .py file into your cura directory as follows:
-* (windows) C:\Users\\*username*\AppData\Roaming\cura\\*version*\scripts
-* (mac) /Users/*username*/Library/Application Support/cura/*version*/scripts
+Copy the `InputShaping.py` file into your cura directory as follows:
+* (Windows) `C:\Users\{USERNAME}\AppData\Roaming\cura\{VERSION}\scripts`
+* (Mac) `/Users/{USERNAME}/Library/Application Support/cura/{VERSION}/scripts`
 
 # Available settings
 1. Motion planning type (M593 or M493)


### PR DESCRIPTION
Check out the simplified version of `M493` ("version 2") that will be included with the final release of Marlin 2.1.3.

https://marlinfw.org/docs/gcode/M493.html

I've altered the G-code to take `XYZE` parameters as flags, so you now set the compensator / shaper for the specified axes with `C`, the base frequency with `A`, the Zeta with `I`, and the VTOL with `Q`. (Send `V` with no parameter to get "FTM V2" reply. No reply = V1.)

For example: `M493 S1 XY C2 A37` is now used instead of `M493 S1 X2 Y2 A37 B37`.